### PR TITLE
Inject cache metadata in model classes only if needed

### DIFF
--- a/sqlacodegen/main.py
+++ b/sqlacodegen/main.py
@@ -36,7 +36,7 @@ def main():
         print('You must supply a url\n', file=sys.stderr)
         parser.print_help()
         return
-    if not args.dogpile and not args.flask:
+    if args.dogpile and not args.flask:
         print('You must use --flask in order to use dogpile option\n', file=sys.stderr)
         parser.print_help()
         return


### PR DESCRIPTION
* Pass the dogpile argument down to the ModelClass class to output cache metadata only if needed
* Fix the flask argument dependency test to raise an error only if dogpile is required