### PR TITLE
Add a way to provide missing engine specificities for code generation

### DIFF
--- a/sqlacodegen/dialects/postgresql.py
+++ b/sqlacodegen/dialects/postgresql.py
@@ -1,0 +1,36 @@
+"""
+Provides missing Postgresql types.
+
+Use GeoAlchemy2 to support Postgis types.
+Implement mockups for Point and LTree type, but generated models won't work out
+of the box: a better way would be to use a package implementing proper classes
+which could be imported in the target project.
+
+"""
+
+from sqlalchemy.dialects.postgresql.base import ischema_names, PGTypeCompiler
+from sqlalchemy import types as sqltypes
+
+try:
+    import geoalchemy2
+except ImportError:
+    pass
+
+
+class LTREE(sqltypes.TypeEngine):
+    """Postgresql LTREE type mockup."""
+
+    __visit_name__ = 'LTREE'
+
+
+class POINT(sqltypes.TypeEngine):
+    """Postgresql POINT type mockup."""
+
+    __visit_name__ = 'POINT'
+
+
+ischema_names['ltree'] = LTREE
+ischema_names['point'] = POINT
+
+PGTypeCompiler.visit_LTREE = lambda self, type_: 'LTREE'
+PGTypeCompiler.visit_POINT = lambda self, type_: 'POINT'

--- a/sqlacodegen/main.py
+++ b/sqlacodegen/main.py
@@ -1,6 +1,7 @@
 """ """
 from __future__ import unicode_literals, division, print_function, absolute_import
 import argparse
+import importlib
 import sys
 
 from sqlalchemy.engine import create_engine
@@ -8,6 +9,15 @@ from sqlalchemy.schema import MetaData
 
 from sqlacodegen.codegen import CodeGenerator
 import sqlacodegen
+import sqlacodegen.dialects
+
+
+def import_dialect_specificities(engine):
+    dialect_name = '.' + engine.dialect.name
+    try:
+        importlib.import_module(dialect_name, 'sqlacodegen.dialects')
+    except ImportError:
+        pass
 
 
 def main():
@@ -42,6 +52,7 @@ def main():
         return
 
     engine = create_engine(args.url)
+    import_dialect_specificities(engine)
     metadata = MetaData(engine)
     tables = args.tables.split(',') if args.tables else None
     fkcols = args.ignorefk.split(',') if args.ignorefk else None


### PR DESCRIPTION
Try to import a dialect specific module to inject missing declaration
from SQLAlchemy (eg. Point and LTree types, or Postgis types).

This prevents missing type errors on generation but the project won't
work out of the box without a proper Type implementation, which
should be provided in an external package like GeoAlchemy2.